### PR TITLE
Added two tests that cover the clear text field button.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
                 <capabilities>/firefox.capabilities</capabilities>
             </properties>
             <activation>
-                <activeByDefault>true</activeByDefault>
+                <activeByDefault>false</activeByDefault>
             </activation>
         </profile>
         <profile>
@@ -101,7 +101,7 @@
                 <capabilities>/chrome.capabilities</capabilities>
             </properties>
             <activation>
-                <activeByDefault>false</activeByDefault>
+                <activeByDefault>true</activeByDefault>
             </activation>
         </profile>
         <profile>

--- a/src/test/java/ca/expedia/SeleniumTests/AllInclusiveTest.java
+++ b/src/test/java/ca/expedia/SeleniumTests/AllInclusiveTest.java
@@ -21,7 +21,7 @@ public class AllInclusiveTest extends TestBase {
 	private AllInclusiveFactory f;
 	private ExtentReports report;
 	private ExtentTest test;
-	private final String REPORT_NAME = "all_inclusive_tab";
+	private final String REPORT_NAME = "all-inclusive-tab";
 	private String originalWindowHandle;
 
 	@BeforeMethod

--- a/src/test/java/ca/expedia/SeleniumTests/CarsTest.java
+++ b/src/test/java/ca/expedia/SeleniumTests/CarsTest.java
@@ -21,7 +21,7 @@ public class CarsTest extends TestBase {
     private CarsFactory f;
     private ExtentReports report;
     private ExtentTest test;
-    private final String REPORT_NAME = "carsTab";
+    private final String REPORT_NAME = "cars-tab";
     private String originalWindowHandle;
 
     @BeforeMethod

--- a/src/test/java/ca/expedia/SeleniumTests/CruisesTest.java
+++ b/src/test/java/ca/expedia/SeleniumTests/CruisesTest.java
@@ -18,7 +18,7 @@ public class CruisesTest extends TestBase{
 	private CruisesFactory f;
 	private ExtentReports report;
 	private ExtentTest test;
-	private final String REPORT_NAME = "cruises_tab";
+	private final String REPORT_NAME = "cruises-tab";
 	private String originalWindowHandle;
 
 	@BeforeMethod

--- a/src/test/java/ca/expedia/SeleniumTests/FlightsTest.java
+++ b/src/test/java/ca/expedia/SeleniumTests/FlightsTest.java
@@ -18,7 +18,7 @@ public class FlightsTest extends TestBase {
     private FlightsFactory f;
     private ExtentReports report;
     private ExtentTest test;
-    private final String REPORT_NAME = "flights_tab";
+    private final String REPORT_NAME = "flights-tab";
     private String originalWindowHandle;
 
     @BeforeMethod

--- a/src/test/java/ca/expedia/SeleniumTests/PageFactory/CommonFactory.java
+++ b/src/test/java/ca/expedia/SeleniumTests/PageFactory/CommonFactory.java
@@ -68,12 +68,12 @@ public abstract class CommonFactory {
     /**
      * This button is in the calendar date selector panel. It allows the user to select a check in date.
      */
-    @FindBy(xpath = "//div[@class='uitk-flex uitk-flex-align-items-center uitk-toolbar uitk-new-date-picker-toolbar']/section/section/button[@type='button'][1]")
+    @FindBy(xpath = "//button[1]/span[@class='uitk-date-picker-selection-date']")
     protected WebElement calendarCheckInButton;
     /**
      * This button is in the calendar date selector panel. It allows the user to select a check out date.
      */
-    @FindBy(xpath = "//div[@class='uitk-flex uitk-flex-align-items-center uitk-toolbar uitk-new-date-picker-toolbar']/section/section/button[@type='button'][2]")
+    @FindBy(xpath = "//button[2]/span[@class='uitk-date-picker-selection-date']")
     protected WebElement calendarCheckOutButton;
     @FindBy(xpath = "//div[contains(@class,'uitk-date-picker-menu-pagination-container')]/button[1]")
     protected WebElement calendarBackArrow;
@@ -83,10 +83,6 @@ public abstract class CommonFactory {
     protected WebElement calendarDoneButton;
     @FindBy(xpath = "//button[@data-testid='submit-button']")
     protected WebElement searchButton;
-    @FindBy(xpath = "//div[@class='uitk-flex uitk-flex-align-items-center uitk-toolbar uitk-new-date-picker-toolbar']/section/section/button[@type='button'][1]/span")
-    protected WebElement calendarCheckInSpan;
-    @FindBy(xpath = "//div[@class='uitk-flex uitk-flex-align-items-center uitk-toolbar uitk-new-date-picker-toolbar']/section/section/button[@type='button'][2]/span")
-    protected WebElement calendarCheckOutSpan;
     @FindBy(xpath = "//div[@class='uitk-new-date-picker-month'][1]/h2")
     protected WebElement leftCalendarHeader;
     @FindBy(xpath = "//div[@class='uitk-new-date-picker-month'][2]/h2")
@@ -105,6 +101,8 @@ public abstract class CommonFactory {
     protected WebElement thingsToDoTab;
     @FindBy(xpath = "//a[@href='?pwaLob=wizard-package-pwa']")
     protected WebElement vacationPackagesTab;
+    @FindBy(xpath="//section[@class='header-region no-stripe']")
+    protected WebElement clickOffMenuLocation;
     private WebDriver driver;
     private ExtentTest test;
 
@@ -397,6 +395,12 @@ public abstract class CommonFactory {
     }
 
     /**
+     * Clicks on the header of the website in order to close a menu.
+     */
+    public void clickOffMenu(){
+        clickOffMenuLocation.click();
+    }
+    /**
      * Starts the report for a specified test.
      *
      * @param report The ExtentReports object from the test class.
@@ -409,7 +413,7 @@ public abstract class CommonFactory {
     /**
      * Method used to log messages from the test class rather than the page factory, typically for pass/fail messages.
      *
-     * @param status The status of the log. E.g., 'LogStatus.INFO', 'LogStatus.ERROR'
+     * @param status  The status of the log. E.g., 'LogStatus.INFO', 'LogStatus.ERROR'
      * @param message The message inside the log.
      */
     public void log(LogStatus status, String message) {
@@ -461,12 +465,12 @@ public abstract class CommonFactory {
         log(LogStatus.INFO, "Clicked on the 'Search' button.");
     }
 
-    public String getCalendarCheckInSpanText() {
-        return calendarCheckInSpan.getText();
+    public String getCalendarCheckInButtonText() {
+        return calendarCheckInButton.getText();
     }
 
-    public String getCalendarCheckOutSpanText() {
-        return calendarCheckOutSpan.getText();
+    public String getCalendarCheckOutButtonText() {
+        return calendarCheckOutButton.getText();
     }
 
     /**
@@ -552,7 +556,7 @@ public abstract class CommonFactory {
     }
 
     /**
-     * Verifies whether the "disabled" attribute of the calendarBackArrow button equals true or not.
+     * Checks whether the "disabled" attribute of the calendarBackArrow button equals true or not.
      *
      * @return True if the button is disabled, else false.
      */
@@ -572,7 +576,7 @@ public abstract class CommonFactory {
     }
 
     /**
-     * Verifies whether the "disabled" attribute of the calendarForwardArrow button equals true or not.
+     * Checks whether the "disabled" attribute of the calendarForwardArrow button equals true or not.
      *
      * @return True if the button is disabled, else false.
      */
@@ -592,7 +596,7 @@ public abstract class CommonFactory {
     }
 
     /**
-     * Verifies that the user is unable to select a day that is in the past on the calendar.
+     * Checks that the user is unable to select a day that is in the past on the calendar.
      *
      * @return True if all the buttons which are in the past are disabled, else false.
      */
@@ -649,7 +653,7 @@ public abstract class CommonFactory {
     }
 
     /**
-     * Verifies user is unable to book a date that is over 500 days from today.
+     * Checks user is unable to book a date that is over 500 days from today.
      *
      * @param fiveHundredDaysIntoFuture LocalDate object whose date is 500 days ahead of the present day.
      * @return True if the day buttons which are over 500 days in the future are disabled, else false.
@@ -725,7 +729,7 @@ public abstract class CommonFactory {
     }
 
     /**
-     * Verifies that the check in day button, check out day button and all the day buttons between are highlighted
+     * Checks that the check in day button, check out day button and all the day buttons between are highlighted
      * correctly. You must have the check in button & check out button selected and be at the check out button's month
      * on the calendar upon calling this method
      *
@@ -775,8 +779,6 @@ public abstract class CommonFactory {
                         driver.findElement(By.xpath("//button[@class='uitk-date-picker-day uitk-new-date-picker-day selected' and @aria-label='"
                                 + checkOutDate.getMonth().getDisplayName(TextStyle.SHORT, Locale.US)
                                 + " " + dayCounter + ", " + checkOutDate.getYear() + ".']"));
-                        System.out.println("Found button on right side : " + checkOutDate.getMonth().getDisplayName(TextStyle.SHORT, Locale.US)
-                                + " " + dayCounter + ", " + checkOutDate.getYear());
                         //If driver finds this element with this xpath, we know it's highlighted correctly.
                     } catch (NoSuchElementException e) {
                         log(LogStatus.ERROR,
@@ -820,8 +822,6 @@ public abstract class CommonFactory {
                     }
                     //Verify that the day buttons in between the check in date and check out date are highlighted correctly.
                     try {
-                        System.out.println("Found button on left side : " + checkOutDate.getMonth().getDisplayName(TextStyle.SHORT, Locale.US)
-                                + " " + dayCounter + ", " + checkOutDate.getYear());
                         driver.findElement(By.xpath("//button[@class='uitk-date-picker-day uitk-new-date-picker-day selected' and @aria-label='"
                                 + checkOutDate.getMonth().getDisplayName(TextStyle.SHORT, Locale.US)
                                 + " " + dayCounter + ", " + checkOutDate.getYear() + ".']"));

--- a/src/test/java/ca/expedia/SeleniumTests/PageFactory/StaysFactory.java
+++ b/src/test/java/ca/expedia/SeleniumTests/PageFactory/StaysFactory.java
@@ -9,12 +9,6 @@ import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.PageFactory;
 import org.openqa.selenium.support.ui.Select;
 
-import java.time.LocalDate;
-import java.time.YearMonth;
-import java.time.format.DateTimeFormatter;
-import java.time.format.TextStyle;
-import java.util.Locale;
-
 /* ToDo:
  * Add logging infrastructure to page factory.
  * Finish creating WebElements for everything on the page.
@@ -24,16 +18,19 @@ public class StaysFactory extends CommonFactory {
     private WebDriver driver;
 
     @FindBy(xpath = "//div[@id='location-field-destination-menu']//button")
-    private WebElement staysGoingToButton;
+    private WebElement goingToButton;
 
     @FindBy(id = "location-field-destination")
-    private WebElement staysGoingToInput;
+    private WebElement goingToInput;
 
     @FindBy(xpath = "//ul[@data-stid='location-field-destination-results']")
-    private WebElement staysGoingToResultList;
+    private WebElement goingToResultList;
 
-    @FindBy(xpath = "//button[@class='uitk-button uitk-button-small uitk-clear-button']")
-    private WebElement clearButton;
+    @FindBy(xpath = "//div[@id='location-field-destination-menu']//button[contains(@class,'uitk-clear-button')]")
+    private WebElement goingToClearButton;
+
+    @FindBy(xpath = "//div[@id='location-field-origin-menu']//button[contains(@class,'uitk-clear-button')]")
+    private WebElement leavingFromClearButton;
 
     @FindBy(id = "add-flight-switch")
     private WebElement addFlightCheckbox;
@@ -42,22 +39,25 @@ public class StaysFactory extends CommonFactory {
     private WebElement addCarCheckbox;
 
     @FindBy(xpath = "//button[@data-testid='add-room-button']")
-    private WebElement staysTravellersAddAnotherRoomButton;
+    private WebElement travellersAddAnotherRoomButton;
 
     @FindBy(xpath = "//button[@data-testid='guests-done-button']")
-    private WebElement staysTravellersDoneButton;
+    private WebElement travellersDoneButton;
 
     @FindBy(xpath = "//button[@data-stid='location-field-origin-menu-trigger']")
-    private WebElement staysLeavingFromButton;
+    private WebElement leavingFromButton;
 
     @FindBy(id = "location-field-origin")
-    private WebElement staysLeavingFromInput;
+    private WebElement leavingFromInput;
 
     @FindBy(xpath = "//ul[@data-stid='location-field-origin-results']")
-    private WebElement staysLeavingFromResultList;
+    private WebElement leavingFromResultList;
 
     @FindBy(xpath = "//button[@data-testid='guests-done-button']")
     private WebElement travellersDone;
+
+    @FindBy(xpath = "//button[@data-testid='guests-done-button']/span")
+    private WebElement travellersDoneSubText;
 
     @FindBy(xpath = "//div[@class='uitk-empty-state-body']")
     private WebElement goingToEmptyState;
@@ -93,33 +93,39 @@ public class StaysFactory extends CommonFactory {
     }
 
     /**
-     * Clicks on the "Going to" button in the "Stays" tab so that we can access the
-     * input field and send keys to it.
+     * Clicks on the "Going to" button in the "Stays" tab so that we can access the input field and send keys to it.
      */
     public void clickGoingTo() {
-        staysGoingToButton.click();
+        goingToButton.click();
         log(LogStatus.INFO, "Clicked on 'Going to'.");
     }
 
     /**
-     * Types the destination into the "Going to" input field. Requires
-     * clickStaysGoingToButton() method to be used before.
+     * Types the destination into the "Going to" input field. Requires clickStaysGoingToButton() method to be used
+     * before.
      *
      * @param destination The destination you wish to search for.
      */
     public void sendKeysGoingTo(String destination) {
-        staysGoingToInput.clear();
-        staysGoingToInput.sendKeys(destination);
+        goingToInput.clear();
+        goingToInput.sendKeys(destination);
         log(LogStatus.INFO, "Typed '" + destination + "' into the 'Going to' field.");
     }
 
     /**
-     * Clicks the clear button. Will use this method for all instances of it for now
-     * unless I run into issues.
+     * Clicks the clear button for the going to field.
      */
-    public void clickClear() {
-        clearButton.click();
-        log(LogStatus.INFO, "Clicked on the X button that clears the text field.");
+    public void clickGoingToClear() {
+        goingToClearButton.click();
+        log(LogStatus.INFO, "Clicked on the X button and cleared the 'Going to' field.");
+    }
+
+    /**
+     * Clicks the clear button for the going to field.
+     */
+    public void clickLeavingFromClear() {
+        leavingFromClearButton.click();
+        log(LogStatus.INFO, "Clicked on the X button and cleared the 'Leaving from' field.");
     }
 
     /**
@@ -139,9 +145,8 @@ public class StaysFactory extends CommonFactory {
     }
 
     /**
-     * Clicks the "Check-in" button so the user may open the calendar and select a
-     * check in date from the calendar date picker panel. Works for all tabs except
-     * for "Multi-city" in flights tab.
+     * Clicks the "Check-in" button so the user may open the calendar and select a check in date from the calendar date
+     * picker panel. Works for all tabs except for "Multi-city" in flights tab.
      */
     public void clickCheckIn() {
         checkInButton.click();
@@ -149,9 +154,8 @@ public class StaysFactory extends CommonFactory {
     }
 
     /**
-     * Clicks the "Check-out" button so the user may open the calendar and select a
-     * check out date from the calendar date picker panel. Works for all tabs except
-     * for "Multi-city" in flights tab.
+     * Clicks the "Check-out" button so the user may open the calendar and select a check out date from the calendar
+     * date picker panel. Works for all tabs except for "Multi-city" in flights tab.
      */
     public void clickCheckOut() {
         checkOutButton.click();
@@ -159,10 +163,9 @@ public class StaysFactory extends CommonFactory {
     }
 
     /**
-     * Clicks the "Travellers" button to open the travellers submenu in the "Stays"
-     * tab.
+     * Clicks the "Travellers" button to open the travellers submenu in the "Stays" tab.
      */
-    public void clickTravellerTab() {
+    public void clickTravellersButton() {
         try {
             WebElement staysTravellerButton = driver
                     .findElement(By.xpath("//button[@data-testid='travelers-field-trigger']"));
@@ -236,13 +239,12 @@ public class StaysFactory extends CommonFactory {
      * Clicks the add another room button. You may only have a maximum of 8 rooms.
      */
     public void clickTravellersAddRoom() {
-        staysTravellersAddAnotherRoomButton.click();
+        travellersAddAnotherRoomButton.click();
         log(LogStatus.INFO, "Clicked on the 'Add another room button' in the travellers tab.");
     }
 
     /**
-     * Clicks the remove room button. There must be at least 2 rooms available on
-     * the travellers panel.
+     * Clicks the remove room button. There must be at least 2 rooms available on the travellers panel.
      *
      * @param room The room number of the element. Range: 2-8
      */
@@ -317,21 +319,20 @@ public class StaysFactory extends CommonFactory {
     }
 
     /**
-     * Clicks the "Leaving from" input so that we may send keys to it. Requires
-     * clicking the "Add a flight" checkbox first.
+     * Clicks the "Leaving from" input so that we may send keys to it. Requires clicking the "Add a flight" checkbox
+     * first.
      */
     public void clickLeavingFrom() {
-        staysLeavingFromButton.click();
+        leavingFromButton.click();
         log(LogStatus.INFO, "Clicked on 'Leaving from'.");
     }
 
     /**
-     * Sends keys to the "Leaving from" input. Requires clicking on the input first,
-     * (use clickStaysLeavingFrom())
+     * Sends keys to the "Leaving from" input. Requires clicking on the input first, (use clickStaysLeavingFrom())
      */
     public void sendKeysLeavingFrom(String keys) {
-        staysLeavingFromInput.clear();
-        staysLeavingFromInput.sendKeys(keys);
+        leavingFromInput.clear();
+        leavingFromInput.sendKeys(keys);
         log(LogStatus.INFO, "Sent the following keys to the 'Leaving from' input: '" + keys + "'");
     }
 
@@ -352,11 +353,15 @@ public class StaysFactory extends CommonFactory {
     }
 
     public String getGoingToButtonText() {
-        return staysGoingToButton.getText();
+        return goingToButton.getText();
+    }
+
+    public String getLeavingFromButtonText() {
+        return leavingFromButton.getText();
     }
 
     public String getGoingToPlaceholderText() {
-        return staysGoingToInput.getAttribute("placeholder");
+        return goingToInput.getAttribute("placeholder");
     }
 
     public String getGoingToEmptyStateText() {
@@ -390,5 +395,34 @@ public class StaysFactory extends CommonFactory {
 
     public String getAddACarLabelText() {
         return addACarLabel.getText();
+    }
+
+    public String getLeavingFromInputValue() {
+        return leavingFromInput.getAttribute("value");
+    }
+
+    public String getGoingToInputValue() {
+        return goingToInput.getAttribute("value");
+    }
+
+    public String getTravellersDoneButtonSubText(){
+        return travellersDoneSubText.getText();
+    }
+    //TODO: Add javadoc
+    public Boolean isTravellersPanelDisplayingRooms(int rooms) {
+        for (int x = rooms; x > 0; x--) {
+            try {
+                driver.findElement(By.xpath("//div[@data-testid='room-" + x + "']"));
+            } catch (NoSuchElementException e) {
+                log(LogStatus.ERROR, "Room " + x + " was not displayed on the travellers panel correctly.");
+                return false;
+            }
+        }
+        if (rooms > 1) {
+            log(LogStatus.INFO, rooms + " rooms were displayed on the travellers panel correctly.");
+        } else {
+            log(LogStatus.INFO, rooms + " room was displayed on the travellers panel correctly.");
+        }
+        return true;
     }
 }

--- a/src/test/java/ca/expedia/SeleniumTests/StaysTest.java
+++ b/src/test/java/ca/expedia/SeleniumTests/StaysTest.java
@@ -21,7 +21,7 @@ public class StaysTest extends TestBase {
     private StaysFactory f;
     private ExtentReports report;
     private ExtentTest test;
-    private final String REPORT_NAME = "stays_tab";
+    private final String REPORT_NAME = "stays-tab";
     private String originalWindowHandle;
 
     @BeforeMethod
@@ -71,7 +71,7 @@ public class StaysTest extends TestBase {
         f.clickCalendarCheckOutDate();
         f.clickCalendarDay(Month.FEBRUARY, 24, 2021);
         f.clickCalendarDone();
-        f.clickTravellerTab();
+        f.clickTravellersButton();
         f.clickTravellersAddRoom();
         f.clickTravellersAddRoom();
         f.clickTravellersChildrenInc(3);
@@ -99,19 +99,9 @@ public class StaysTest extends TestBase {
         f.clickAddCar();
     }
 
-    @Test(enabled = false)
-    public void bigAssAssertionTest() {
-        f.createTestReport(report, "Big Ass Assertion Test");
-        f.clickCheckIn();
-        for (int x = 0; x < 5; x++) {
-            f.clickCalendarForwardArrow();
-        }
-        //Assert.assertTrue(f.verifyCalendarDaysAreHighlightedCorrectly());
-    }
-
     @Test
-    public void verifyUserCannotAccessPastMonth() {
-        f.createTestReport(report, "Verify User Cannot Access A Month That Is In The Past");
+    public void assertUserCannotAccessPastMonth() {
+        f.createTestReport(report, "Assert User Cannot Access A Month That Is In The Past");
         f.clickStaysTab();
         f.clickCheckIn();
         f.navigateToPresentMonth();
@@ -119,18 +109,18 @@ public class StaysTest extends TestBase {
     }
 
     @Test
-    public void verifyUserCannotAccessMonth500DaysAhead() {
-        f.createTestReport(report, "Verify User Cannot Access Month That Is Over 500 Days Ahead.");
+    public void assertUserCannotAccessMonth500DaysAhead() {
+        LocalDate fiveHundredDaysAhead = LocalDate.now().plusDays(500);
+        f.createTestReport(report, "Assert User Cannot Access Month That Is Over 500 Days Ahead.");
         f.clickStaysTab();
         f.clickCheckIn();
-        LocalDate fiveHundredDaysAhead = LocalDate.now().plusDays(500);
-        f.navigateToFutureMonth(fiveHundredDaysAhead.getMonth(), fiveHundredDaysAhead.getYear());
+        f.navigateToMonth(fiveHundredDaysAhead.getMonth(), fiveHundredDaysAhead.getYear());
         Assert.assertTrue(f.isCalendarForwardArrowDisabled());
     }
 
     @Test
-    public void verifyUserCannotSelectDayInPast() {
-        f.createTestReport(report, "Verify User Cannot Select A Calendar Day That Is In The Past");
+    public void assertUserCannotSelectDayInPast() {
+        f.createTestReport(report, "Assert User Cannot Select A Calendar Day That Is In The Past");
         f.clickStaysTab();
         f.clickCheckIn();
         f.navigateToPresentMonth();
@@ -138,25 +128,70 @@ public class StaysTest extends TestBase {
     }
 
     @Test
-    public void verifyUserCannotSelectDaysThatAre500DaysInFuture() {
-        f.createTestReport(report, "Verify User Cannot Select A Day That Is Over 500 Days In The Future");
+    public void assertUserCannotSelectDaysThatAre500DaysInFuture() {
+        LocalDate fiveHundredDaysAhead = LocalDate.now().plusDays(500);
+        f.createTestReport(report, "Assert User Cannot Select A Day That Is Over 500 Days In The Future");
         f.clickStaysTab();
         f.clickCheckIn();
-        LocalDate fiveHundredDaysAhead = LocalDate.now().plusDays(500);
-        f.navigateToFutureMonth(fiveHundredDaysAhead.getMonth(), fiveHundredDaysAhead.getYear());
+        f.navigateToMonth(fiveHundredDaysAhead.getMonth(), fiveHundredDaysAhead.getYear());
         Assert.assertTrue(f.isUserUnableToSelectDayOver500InFuture(fiveHundredDaysAhead));
     }
 
     @Test
-    public void verifyCalendarDaysAreHighlightedCorrectly() {
-        f.createTestReport(report, "Verify Calendar Days Are Highlighted Correctly");
+    public void assertCalendarDaysAreHighlightedCorrectly() {
+        LocalDate presentDate = LocalDate.now();
+        LocalDate date500DaysIntoFuture = LocalDate.now().plusDays(500);
+        f.createTestReport(report, "Assert Calendar Days Are Highlighted Correctly");
         f.clickStaysTab();
         f.clickCheckIn();
-        LocalDate presentDate = LocalDate.of(2021,3,15);
-        LocalDate date500DaysIntoFuture = LocalDate.now().plusDays(500);
         f.clickCalendarDayAfterNavigating(presentDate.getMonth(), presentDate.getDayOfMonth(), presentDate.getYear());
         f.clickCalendarDayAfterNavigating(date500DaysIntoFuture.getMonth(),
                 date500DaysIntoFuture.getDayOfMonth(), date500DaysIntoFuture.getYear());
         Assert.assertTrue(f.isCalendarHighlightingDaysCorrectly(presentDate, date500DaysIntoFuture));
+    }
+
+    @Test
+    public void assertUserCanClearGoingToFieldWithXButton(){
+        f.createTestReport(report,"Assert User Can Clear Going To Field With 'x' Button");
+        f.clickStaysTab();
+        f.clickGoingTo();
+        f.sendKeysGoingTo("Toronto");
+        f.clickGoingToClear();
+        Assert.assertEquals(f.getGoingToInputValue(),"");
+        f.sendKeysGoingTo("Toronto");
+        f.clickSearchResult("Toronto (YYZ - Pearson Intl.)", "Ontario, Canada");
+        f.clickGoingTo();
+        f.clickGoingToClear();
+        Assert.assertEquals(f.getGoingToInputValue(),"");
+        f.clickOffMenu();
+        Assert.assertEquals(f.getGoingToButtonText(),"");
+    }
+
+    @Test
+    public void assertUserCanClearLeavingFromFieldWithXButton(){
+        f.createTestReport(report,"Assert User Can Clear Leaving From Field With 'x' Button");
+        f.clickStaysTab();
+        f.clickAddFlight();
+        f.clickLeavingFrom();
+        f.sendKeysLeavingFrom("Toronto");
+        f.clickLeavingFromClear();
+        Assert.assertEquals(f.getLeavingFromInputValue(),"");
+        f.sendKeysLeavingFrom("Toronto");
+        f.clickSearchResult("Toronto (YYZ - Pearson Intl.)", "Ontario, Canada");
+        f.clickLeavingFrom();
+        f.clickLeavingFromClear();
+        Assert.assertEquals(f.getLeavingFromInputValue(),"");
+        f.clickOffMenu();
+        Assert.assertEquals(f.getLeavingFromButtonText(),"");
+    }
+    @Test()
+    public void assertCorrectNumberOfRoomsAreDisplayed() {
+        f.createTestReport(report,"Assert The Correct Number of Rooms Are Displayed For Travellers");
+        f.clickStaysTab();
+        Assert.assertEquals(f.getTravellersText(), "1 room, 2 travellers");
+        f.clickTravellersButton();
+        Assert.assertTrue(f.isTravellersPanelDisplayingRooms(1));
+        Assert.assertEquals(f.getTravellersDoneButtonSubText(), "1 room, 2 travellers");
+        f.clickTravellersAddRoom();
     }
 }

--- a/src/test/java/ca/expedia/SeleniumTests/ThingsToDoTest.java
+++ b/src/test/java/ca/expedia/SeleniumTests/ThingsToDoTest.java
@@ -21,7 +21,7 @@ public class ThingsToDoTest extends TestBase {
     private ThingsToDoFactory f;
     private ExtentReports report;
     private ExtentTest test;
-    private final String REPORT_NAME = "things_to_do_tab";
+    private final String REPORT_NAME = "things-to-do-tab";
     private String originalWindowHandle;
 
     @BeforeMethod

--- a/src/test/java/ca/expedia/SeleniumTests/VacationTest.java
+++ b/src/test/java/ca/expedia/SeleniumTests/VacationTest.java
@@ -19,7 +19,7 @@ public class VacationTest extends TestBase {
     private VacationFactory f;
     private ExtentReports report;
     private ExtentTest test;
-    private final String REPORT_NAME = "vacation_tab";
+    private final String REPORT_NAME = "vacation-tab";
     private String originalWindowHandle;
 
     @BeforeMethod


### PR DESCRIPTION
- Made chromedriver default driver.
- Changed '_' to '-' for report names to resolve issue with ExtentReports.
- Calendar check in/check out buttons  have improved xpaths and now search for span child element as well.
- Removed calendar check in/check out span elements as they have been made redundant.
- Added function to "click off menus" for CommonFactory so we can dismiss menus that pop up. 
- Removed leftover print statements from debugging.
- Renamed WebElement objects in the StaysFactory class to ones that had less redundant names.
